### PR TITLE
Fix dependency resolutions for dnt

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,9 +9,20 @@
       "./shims": "./src/shims/mod.ts"
    },
    "publish": {
-      "exclude": [".git", ".github", "dnt.ts", "npm", "coverage", "tests"]
+      "exclude": [
+         ".git",
+         ".github",
+         "dnt.ts",
+         "npm",
+         "coverage",
+         "tests"
+      ]
    },
-   "exclude": [".git", "npm", "coverage", "src/_deps.ts"],
+   "imports": {
+      "@standard-schema/spec": "jsr:@standard-schema/spec@^1.0.0",
+      "valibot": "jsr:@valibot/valibot@^1.0.0"
+   },
+   "exclude": [".git", "npm", "coverage"],
    "lock": false,
    "fmt": {
       "indentWidth": 3,
@@ -26,6 +37,8 @@
       "check:extensions": "deno check src/extensions/mod.ts",
       "check:patch": "deno check src/patch/mod.ts",
       "check:shims": "deno check src/shims/mod.ts",
+      "check:jsr": "deno publish --dry-run",
+      "check:npm": "cd npm && npx depcheck && npm publish --dry-run",
       "test": "deno task test:clean || true && deno task test:run && deno task test:coverage",
       "test:coverage": "deno coverage --html",
       "test:run": "deno test --parallel --allow-read --coverage tests/",

--- a/src/_deps.ts
+++ b/src/_deps.ts
@@ -1,2 +1,0 @@
-export * as v from 'valibot';
-export * from '@standard-schema/spec';

--- a/src/beatmap/schema/external/declaration/bookmarks.ts
+++ b/src/beatmap/schema/external/declaration/bookmarks.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type { IBookmarkElement, IBookmarks } from '../types/bookmarks.ts';
 import { entity, field, type InferObjectEntries } from '../../helpers.ts';
 import { CharacteristicNameSchema, DifficultyNameSchema } from '../../shared/declaration/common.ts';

--- a/src/beatmap/schema/helpers.ts
+++ b/src/beatmap/schema/helpers.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { v } from '../../deps.ts';
+import * as v from 'valibot';
 import { logger } from '../../logger.ts';
 import type { Version } from '../schema/shared/types/version.ts';
 import { isRecord } from '../../utils/misc/json.ts';

--- a/src/beatmap/schema/shared/declaration/common.ts
+++ b/src/beatmap/schema/shared/declaration/common.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import {
    Axis,
    CharacteristicName,

--- a/src/beatmap/schema/shared/declaration/custom/contributor.ts
+++ b/src/beatmap/schema/shared/declaration/custom/contributor.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { IContributor } from '../../types/custom/contributor.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';
 

--- a/src/beatmap/schema/shared/declaration/vector.ts
+++ b/src/beatmap/schema/shared/declaration/vector.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 
 /** Schema declaration for one-dimensional vector tuple. */
 export const Vector1Schema = v.tuple([v.number()]);

--- a/src/beatmap/schema/v1/declaration/difficulty.ts
+++ b/src/beatmap/schema/v1/declaration/difficulty.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type { IDifficulty, IEvent, INote, IObstacle } from '../types/mod.ts';
 import type { IBookmark } from '../../v2/types/custom/bookmark.ts';
 import type { IBPMChangeOld } from '../../v2/types/custom/bpmChange.ts';

--- a/src/beatmap/schema/v1/declaration/info.ts
+++ b/src/beatmap/schema/v1/declaration/info.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type { EnvironmentName, EnvironmentV3Name } from '../../shared/types/environment.ts';
 import type { IInfo, IInfoDifficulty } from '../types/info.ts';
 import type { IColor } from '../../../../types/colors.ts';

--- a/src/beatmap/schema/v2/declaration/audioData.ts
+++ b/src/beatmap/schema/v2/declaration/audioData.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type { IBPMInfo, IBPMInfoRegion } from '../../../schema/v2/types/bpmInfo.ts';
 import { entity, field, type InferObjectEntries, mask } from '../../helpers.ts';
 import { VersionSchema } from '../../shared/declaration/mod.ts';

--- a/src/beatmap/schema/v2/declaration/custom/bookmark.ts
+++ b/src/beatmap/schema/v2/declaration/custom/bookmark.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { IBookmark } from '../../types/custom/bookmark.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';
 import { Vector3ColorSchema, Vector4ColorSchema } from '../../../shared/declaration/vector.ts';

--- a/src/beatmap/schema/v2/declaration/custom/bpmChange.ts
+++ b/src/beatmap/schema/v2/declaration/custom/bpmChange.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { IBPMChange, IBPMChangeOld } from '../../types/custom/bpmChange.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';
 

--- a/src/beatmap/schema/v2/declaration/custom/colorScheme.ts
+++ b/src/beatmap/schema/v2/declaration/custom/colorScheme.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { IColorScheme } from '../../types/custom/colorScheme.ts';
 import type { IColor } from '../../../../../types/colors.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';

--- a/src/beatmap/schema/v2/declaration/custom/difficulty.ts
+++ b/src/beatmap/schema/v2/declaration/custom/difficulty.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { ICustomDataDifficulty } from '../../types/custom/difficulty.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';
 import { CustomBookmarkSchema } from './bookmark.ts';

--- a/src/beatmap/schema/v2/declaration/custom/editor.ts
+++ b/src/beatmap/schema/v2/declaration/custom/editor.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { IEditor, IEditorInfo } from '../../types/custom/editor.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';
 

--- a/src/beatmap/schema/v2/declaration/custom/info.ts
+++ b/src/beatmap/schema/v2/declaration/custom/info.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type {
    ICustomDataInfo,
    ICustomDataInfoDifficulty,

--- a/src/beatmap/schema/v2/declaration/difficulty.ts
+++ b/src/beatmap/schema/v2/declaration/difficulty.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type {
    IArc,
    IDifficulty,

--- a/src/beatmap/schema/v2/declaration/info.ts
+++ b/src/beatmap/schema/v2/declaration/info.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type {
    Environment360Name,
    EnvironmentAllName,

--- a/src/beatmap/schema/v3/declaration/custom/bookmark.ts
+++ b/src/beatmap/schema/v3/declaration/custom/bookmark.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { IBookmark } from '../../types/custom/bookmark.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';
 import { Vector3ColorSchema, Vector4ColorSchema } from '../../../shared/declaration/vector.ts';

--- a/src/beatmap/schema/v3/declaration/custom/bpmChange.ts
+++ b/src/beatmap/schema/v3/declaration/custom/bpmChange.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { IBPMChange } from '../../types/custom/bpmChange.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';
 

--- a/src/beatmap/schema/v3/declaration/custom/difficulty.ts
+++ b/src/beatmap/schema/v3/declaration/custom/difficulty.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type { ICustomDataDifficulty } from '../../types/custom/difficulty.ts';
 import type { InferObjectEntries } from '../../../helpers.ts';
 import { CustomBookmarkSchema } from './bookmark.ts';

--- a/src/beatmap/schema/v3/declaration/difficulty.ts
+++ b/src/beatmap/schema/v3/declaration/difficulty.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type {
    IArc,
    IBasicEvent,

--- a/src/beatmap/schema/v3/declaration/lightshow.ts
+++ b/src/beatmap/schema/v3/declaration/lightshow.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type { ILightshow } from '../types/lightshow.ts';
 import { entity, field, type InferObjectEntries } from '../../helpers.ts';
 import { CustomDataSchema } from '../../shared/declaration/mod.ts';

--- a/src/beatmap/schema/v4/declaration/audioData.ts
+++ b/src/beatmap/schema/v4/declaration/audioData.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type { IAudio, IAudioBPM, IAudioLUFS } from '../types/audioData.ts';
 import { entity, field, type InferObjectEntries, mask } from '../../helpers.ts';
 import { VersionSchema } from '../../shared/declaration/mod.ts';

--- a/src/beatmap/schema/v4/declaration/common.ts
+++ b/src/beatmap/schema/v4/declaration/common.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type { IObject, IObjectArc, IObjectChain, IObjectLane } from '../types/object.ts';
 import { field, type InferObjectEntries } from '../../helpers.ts';
 import { CustomDataSchema } from '../../shared/declaration/mod.ts';

--- a/src/beatmap/schema/v4/declaration/custom/info.ts
+++ b/src/beatmap/schema/v4/declaration/custom/info.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../../deps.ts';
+import * as v from 'valibot';
 import type {
    ICustomCharacteristic,
    ICustomDataInfo,

--- a/src/beatmap/schema/v4/declaration/difficulty.ts
+++ b/src/beatmap/schema/v4/declaration/difficulty.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type {
    IArc,
    IBombNote,

--- a/src/beatmap/schema/v4/declaration/info.ts
+++ b/src/beatmap/schema/v4/declaration/info.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type { EnvironmentAllName } from '../../shared/types/mod.ts';
 import type {
    IInfo,

--- a/src/beatmap/schema/v4/declaration/lightshow.ts
+++ b/src/beatmap/schema/v4/declaration/lightshow.ts
@@ -1,4 +1,4 @@
-import { v } from '../../../../deps.ts';
+import * as v from 'valibot';
 import type {
    IBasicEvent,
    IColorBoostEvent,

--- a/src/beatmap/validator/json.ts
+++ b/src/beatmap/validator/json.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import type { StandardSchemaV1 } from '../../deps.ts';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { logger } from '../../logger.ts';
 import type { ISchemaCheckOptions } from '../mapping/types/schema.ts';
 import type { BeatmapFileType } from '../schema/shared/types/schema.ts';

--- a/src/beatmap/validator/schema.ts
+++ b/src/beatmap/validator/schema.ts
@@ -1,4 +1,4 @@
-import type { StandardSchemaV1 } from '../../deps.ts';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { logger } from '../../logger.ts';
 import type { ISchemaCheckOptions } from '../mapping/types/schema.ts';
 import type { ISchemaDeclaration } from '../schema/shared/types/schema.ts';

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,2 +1,0 @@
-export * as v from 'jsr:@valibot/valibot@^1.0.0';
-export * from 'jsr:@standard-schema/spec@^1.0.0';

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,4 +1,5 @@
-import { type StandardSchemaV1, v } from '../src/deps.ts';
+import * as v from 'valibot';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { entity, field, mask } from '../src/beatmap/schema/helpers.ts';
 import * as v4 from '../src/beatmap/schema/v4/declaration/mod.ts';
 import type { ISchemaDeclaration } from '../src/beatmap/schema/shared/types/schema.ts';
@@ -37,13 +38,13 @@ function object(shape: { [key: string]: StandardSchemaV1 }): StandardSchemaV1 {
             }
             const children = Object.keys(shape).reduce((acc, key) => {
                const result = shape[key]['~standard'].validate(
-                  data[key as keyof object]
+                  data[key as keyof object],
                );
                if (!('issues' in result) || !result.issues) return acc;
                return acc.concat(
                   ...result.issues.map((x) => {
                      return { ...x, path: [key, ...(x.path ?? [])] };
-                  })
+                  }),
                );
             }, [] as StandardSchemaV1.Issue[]);
             return { issues: children };
@@ -101,7 +102,7 @@ Deno.test('entity serialization tests', async (ctx) => {
          foo: v.array(
             v.object({
                bar: field(v.boolean(), { version: '1.2.0' }),
-            })
+            }),
          ),
       });
       await ctx.step('all supported fields present', () => {
@@ -111,7 +112,7 @@ Deno.test('entity serialization tests', async (ctx) => {
          });
          assertEquals(
             'issues' in result && result.issues && result.issues.length > 0,
-            false
+            false,
          );
       });
       await ctx.step('missing field for version', () => {
@@ -121,7 +122,7 @@ Deno.test('entity serialization tests', async (ctx) => {
          });
          assertEquals(
             'issues' in result && result.issues && result.issues.length > 0,
-            true
+            true,
          );
       });
       await ctx.step('version mismatch', () => {
@@ -131,7 +132,7 @@ Deno.test('entity serialization tests', async (ctx) => {
          });
          assertEquals(
             'issues' in result && result.issues && result.issues.length > 0,
-            true
+            true,
          );
       });
       await ctx.step('valid for unsupported fields', () => {
@@ -141,7 +142,7 @@ Deno.test('entity serialization tests', async (ctx) => {
          });
          assertEquals(
             'issues' in result && result.issues && result.issues.length > 0,
-            false
+            false,
          );
       });
    });
@@ -156,7 +157,7 @@ Deno.test('beatmap serialization tests', async (ctx) => {
       const result = v4.DifficultySchema['~standard'].validate(data);
       assertEquals(
          'issues' in result && result.issues && result.issues.length > 0,
-         false
+         false,
       );
    });
 });


### PR DESCRIPTION
looking into ways to improve tree-shaking for the library, and one of the biggest pain points comes from the hacks you have around file mappings for dependency resolution, since the barrel exports make it impossible to eliminate unused modules from packages with exports (like valibot).

while i fully understand why it was done this way (and have since discovered the pains of jsr specifier resolution for myself 🙃), i think i found a viable means of performing dependency remapping without the need for awkward file mapping hacks or barrel exports. these changes shouldn't make any noticeable difference to the build steps in theory, and in turn results in a roughly 200kb reduction in bundle size from the main export.

> added some tasks to deno.json so i could do integrity checks for publishing steps (`check:npm` and `check:jsr`). obviously can't test the real publishing flow for 100% certainty but hopefully they can give you a safety net for ensuring things are consistent on your end before a real publishing run.

it's by no means foolproof, since you have to bypass dnt's resolution of import maps and do some aliasing to make it work, and we still can't ensure proper resolution of jsr deps without manual configurations on the user's end (recent updates to pnpm and yarn have since [introduced automated support for jsr specifier resolutions](https://deno.com/blog/add-jsr-with-pnpm-yarn), and npm support is underway), but this isn't a major blocker for the current state of the library since our deps are both npm-equivalent, and we can always cross that bridge if/when we get to it.

there's also the option of just vendoring the current deps from npm on both distributions if we wanted to remove the maintenance burden for remappings entirely, but i'll leave the verdict to you.
