### PR TITLE
Backport free obstacles to legacy formats

### DIFF
--- a/src/beatmap/schema/v1/obstacle.ts
+++ b/src/beatmap/schema/v1/obstacle.ts
@@ -2,11 +2,7 @@ import type { ISchemaContainer } from '../shared/types/schema.ts';
 import type { IObstacle } from './types/obstacle.ts';
 import type { IWrapObstacle } from '../wrapper/types/obstacle.ts';
 import { createObstacle } from '../wrapper/obstacle.ts';
-import {
-   isBoundedObstacle,
-   isCrouchHeightObstacle,
-   isFullHeightObstacle,
-} from '../../helpers/core/obstacle.ts';
+import { isCrouchHeightObstacle, isFullHeightObstacle } from '../../helpers/core/obstacle.ts';
 
 function fixPosYForExtendedType(type: number): number {
    if (type < 1000 || type > 4005000) return 0;
@@ -25,18 +21,14 @@ function fixHeightForExtendedType(type: number) {
 export const obstacle: ISchemaContainer<IWrapObstacle, IObstacle> = {
    serialize(data) {
       let type = 0;
-      if (data.height >= 0 && data.posY >= 0) {
+      if (Math.abs(data.height) < 1000 && Math.abs(data.posY) < 1000) {
+         type = Math.floor((data.height * 200000) + (data.posY * 200) + 4001);
+      } else {
          const posY = data.posY >= 1000 ? data.posY - 1000 : data.posY / 1000;
          const height = data.height >= 1000 ? data.height - 1000 : data.height / 1000;
          type = Math.floor((height / 5) * 1000 + (posY / 5) + 4001);
       }
-      type = isFullHeightObstacle(data)
-         ? 0
-         : isCrouchHeightObstacle(data)
-         ? 1
-         : isBoundedObstacle(data)
-         ? data.posY >= 2 ? 1 : 0
-         : type;
+      type = isFullHeightObstacle(data) ? 0 : isCrouchHeightObstacle(data) ? 1 : type;
       return {
          _time: data.time,
          _type: type,

--- a/src/beatmap/schema/v2/obstacle.ts
+++ b/src/beatmap/schema/v2/obstacle.ts
@@ -3,11 +3,7 @@ import type { IObstacle } from '../../schema/v2/types/obstacle.ts';
 import type { IWrapObstacle } from '../wrapper/types/obstacle.ts';
 import { deepCopy } from '../../../utils/misc/json.ts';
 import { createObstacle } from '../wrapper/obstacle.ts';
-import {
-   isBoundedObstacle,
-   isCrouchHeightObstacle,
-   isFullHeightObstacle,
-} from '../../helpers/core/obstacle.ts';
+import { isCrouchHeightObstacle, isFullHeightObstacle } from '../../helpers/core/obstacle.ts';
 
 function fixPosYForExtendedType(type: number): number {
    if (type < 1000 || type > 4005000) return 0;
@@ -26,18 +22,14 @@ function fixHeightForExtendedType(type: number) {
 export const obstacle: ISchemaContainer<IWrapObstacle, IObstacle> = {
    serialize(data) {
       let type = 0;
-      if (data.height >= 0 && data.posY >= 0) {
+      if (Math.abs(data.height) < 1000 && Math.abs(data.posY) < 1000) {
+         type = Math.floor((data.height * 200000) + (data.posY * 200) + 4001);
+      } else {
          const posY = data.posY >= 1000 ? data.posY - 1000 : data.posY / 1000;
          const height = data.height >= 1000 ? data.height - 1000 : data.height / 1000;
          type = Math.floor((height / 5) * 1000 + (posY / 5) + 4001);
       }
-      type = isFullHeightObstacle(data)
-         ? 0
-         : isCrouchHeightObstacle(data)
-         ? 1
-         : isBoundedObstacle(data)
-         ? data.posY >= 2 ? 1 : 0
-         : type;
+      type = isFullHeightObstacle(data) ? 0 : isCrouchHeightObstacle(data) ? 1 : type;
       return {
          _time: data.time,
          _type: type,


### PR DESCRIPTION
this PR adds support for serializing unbounded `posY` and `height` values for legacy map formats (v1/v2), which effectively allows free obstacles to be converted cleanly to all map formats (so long as you add mapping extensions as a requirement). 

pretty straightforward, makes much more sense than the janky clamping we had before.